### PR TITLE
fix : 파트너 set으로 변경 + 출석체크 시 가이드의 경우에도 파트너 반영되도록 변경

### DIFF
--- a/run/src/main/java/com/guide/run/event/service/EventAttendService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventAttendService.java
@@ -19,6 +19,7 @@ import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.xmlbeans.impl.regex.Match;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +45,9 @@ public class EventAttendService {
         Attendance attendance = attendanceRepository.findByEventIdAndPrivateId(eventId, user.getPrivateId());
         if(attendance.isAttend()){
             if(user.getType().equals(UserType.VI)){
-                setAttendPartnerList(eventId, user);
+                setAttendViPartnerList(eventId, user);
+            }else{
+                setAttendGuidePartner(eventId, user);
             }
             attendanceRepository.save(
                     Attendance.builder()
@@ -58,7 +61,9 @@ public class EventAttendService {
         }
         else{
             if(user.getType().equals(UserType.VI)){
-                setNotAttendPartnerList(eventId, user);
+                setNotAttendViPartnerList(eventId, user);
+            }else{
+                setNotAttendGuidePartner(eventId, user);
             }
             attendanceRepository.save(
                     Attendance.builder()
@@ -101,7 +106,7 @@ public class EventAttendService {
 
 
     @Transactional
-    public void setAttendPartnerList(long eventId, User vi){
+    public void setAttendViPartnerList(long eventId, User vi){
         log.info("setAttendPartnerList - privateId : {}", vi.getPrivateId());
         Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
         //매칭된 회원 조회
@@ -130,7 +135,35 @@ public class EventAttendService {
     }
 
     @Transactional
-    public void setNotAttendPartnerList(long eventId, User vi){
+    public void setAttendGuidePartner(long eventId, User guide){
+        log.info("setAttendGuidePartner - privateId : {}", guide.getPrivateId());
+        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
+        //매칭된 회원 조회
+        Matching matching = matchingRepository.findByEventIdAndGuideId(eventId, guide.getPrivateId());
+
+        if(matching!=null){
+            boolean isAttend = attendanceRepository.findByEventIdAndPrivateId(eventId, matching.getViId()).isAttend();
+
+            //vi가 출석했다면 파트너 추가
+            if(isAttend){
+                // 파트너 조회. 존재하지 않으면 신규 생성
+                Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId())
+                        .orElseGet(() -> Partner.builder()
+                                .viId(matching.getViId())
+                                .guideId(matching.getGuideId())
+                                .contestIds(new HashSet<>())
+                                .trainingIds(new HashSet<>())
+                                .build());
+
+                boolean isTraining = EventType.TRAINING.equals(e.getType());
+                addEventPartner(partner, matching.getEventId(), isTraining);
+            }
+        }
+
+    }
+
+    @Transactional
+    public void setNotAttendViPartnerList(long eventId, User vi){
         log.info("setNotAttendPartnerList - privateId : {}", vi.getPrivateId());
         Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
 
@@ -146,6 +179,23 @@ public class EventAttendService {
             }
         }
 
+    }
+
+    @Transactional
+    public void setNotAttendGuidePartner(long eventId, User guide){
+        log.info("notAttendGuidePartner - privateId : {}", guide.getPrivateId());
+        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
+
+        Matching matching = matchingRepository.findByEventIdAndGuideId(eventId, guide.getPrivateId());
+        if(matching!=null){
+            // 파트너 조회 후 해당 이벤트가 있으면 삭제.
+            Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId()).orElse(null);
+
+            if(partner!=null){
+                boolean isTraining = EventType.TRAINING.equals(e.getType());
+                removeEventPartner(partner, matching.getEventId(), isTraining);
+            }
+        }
     }
 
     @Transactional

--- a/run/src/main/java/com/guide/run/partner/entity/dto/MyPagePartner.java
+++ b/run/src/main/java/com/guide/run/partner/entity/dto/MyPagePartner.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -30,8 +31,8 @@ public class MyPagePartner {
                          UserType type,
                          String name,
                          String recordDegree,
-                         List<Long> trainingIds,
-                         List<Long> contestIds,
+                         Set<Long> trainingIds,
+                         Set<Long> contestIds,
                          long like,
                          String sendId,
                          String privateId ) {


### PR DESCRIPTION
<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 출석 관리 방식이 개선되어, VI 사용자와 GUIDE 사용자에 대해 맞춤형 출석 및 불참 처리가 이루어집니다.
  
- **리팩터**
  - 파트너 관련 정보 집계 로직이 수정되어, 연수 및 대회 참가 수치가 중복 없이 보다 정확하게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->