### PR TITLE
fix : 매칭 시 (둘 다 출석한 경우) 파트너 리스트 반영하도록 코드 추가

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryAdminImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryAdminImpl.java
@@ -111,8 +111,8 @@ public class EventRepositoryAdminImpl implements EventRepositoryAdmin{
                                 event.isApprove.as("approval"),
                                 event.maxNumV.as("minNumV"),
                                 event.maxNumG.as("minNumG"),
-                                formattedDate(event.updatedAt).as("update_date"),
-                                formattedTime(event.updatedAt).as("update_time")
+                                formattedDate(event.createdAt).as("update_date"),
+                                formattedTime(event.createdAt).as("update_time")
                         )
                 )
                 .from(event, user)
@@ -209,8 +209,8 @@ public class EventRepositoryAdminImpl implements EventRepositoryAdmin{
                                 event.isApprove.as("approval"),
                                 event.maxNumV.as("minNumV"),
                                 event.maxNumG.as("minNumG"),
-                                formattedDate(event.updatedAt).as("update_date"),
-                                formattedTime(event.updatedAt).as("update_time")
+                                formattedDate(event.createdAt).as("update_date"),
+                                formattedTime(event.createdAt).as("update_time")
                         )
                 )
                 .from(event, user)
@@ -321,7 +321,7 @@ public class EventRepositoryAdminImpl implements EventRepositoryAdmin{
 
 
         if (cond.getTime()==0) {
-            orderSpecifiers.add(new OrderSpecifier(Order.DESC, event.updatedAt));
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, event.createdAt));
         }
 
         if (cond.getOrganizer()==0) {
@@ -345,7 +345,7 @@ public class EventRepositoryAdminImpl implements EventRepositoryAdmin{
         }
 
         if (cond.getTime()==1) {
-            orderSpecifiers.add(new OrderSpecifier(Order.ASC, event.updatedAt));
+            orderSpecifiers.add(new OrderSpecifier(Order.ASC, event.createdAt));
         }
 
         if (cond.getOrganizer()==1) {
@@ -353,7 +353,7 @@ public class EventRepositoryAdminImpl implements EventRepositoryAdmin{
         }
 
         if(cond.getOrganizer()==2 && cond.getTime()==2 && cond.getApproval()==2 && cond.getName()==2){
-            orderSpecifiers.add(new OrderSpecifier(Order.DESC, event.updatedAt));
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, event.createdAt));
         }
 
         return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);

--- a/run/src/main/java/com/guide/run/event/service/EventAttendService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventAttendService.java
@@ -14,6 +14,7 @@ import com.guide.run.partner.entity.partner.Partner;
 import com.guide.run.partner.entity.partner.repository.PartnerRepository;
 import com.guide.run.attendance.entity.Attendance;
 import com.guide.run.attendance.repository.AttendanceRepository;
+import com.guide.run.partner.service.PartnerService;
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.user.UserRepository;
@@ -35,19 +36,17 @@ import java.util.Set;
 public class EventAttendService {
     private final AttendanceRepository attendanceRepository;
     private final UserRepository userRepository;
-    private final PartnerRepository partnerRepository;
-    private final MatchingRepository matchingRepository;
-    private final EventRepository eventRepository;
     private final AttendService attendService;
+    private final PartnerService partnerService;
 
     public void requestAttend(Long eventId, String userId) {
         User user = userRepository.findUserByUserId(userId).orElseThrow(NotExistUserException::new);
         Attendance attendance = attendanceRepository.findByEventIdAndPrivateId(eventId, user.getPrivateId());
         if(attendance.isAttend()){
             if(user.getType().equals(UserType.VI)){
-                setNotAttendViPartnerList(eventId, user);
+                partnerService.setNotAttendViPartnerList(eventId, user);
             }else if(user.getType().equals(UserType.GUIDE)){
-                setNotAttendGuidePartner(eventId, user);
+                partnerService.setNotAttendGuidePartner(eventId, user);
             }
             attendanceRepository.save(
                     Attendance.builder()
@@ -61,9 +60,9 @@ public class EventAttendService {
         }
         else{
             if(user.getType().equals(UserType.VI)){
-                setAttendViPartnerList(eventId, user);
+                partnerService.setAttendViPartnerList(eventId, user);
             }else if(user.getType().equals(UserType.GUIDE)){
-                setAttendGuidePartner(eventId, user);
+                partnerService.setAttendGuidePartner(eventId, user);
             }
             attendanceRepository.save(
                     Attendance.builder()
@@ -102,140 +101,6 @@ public class EventAttendService {
                 .attend(attendanceRepository.getParticipationInfo(eventId,true))
                 .notAttend(attendanceRepository.getParticipationInfo(eventId,false))
                 .build();
-    }
-
-
-    @Transactional
-    public void setAttendViPartnerList(long eventId, User vi){
-        log.info("setAttendPartnerList - privateId : {}", vi.getPrivateId());
-        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
-        //매칭된 회원 조회
-        List<Matching> matchings = matchingRepository.findAllByEventIdAndViId(eventId, vi.getPrivateId());
-        for (Matching matching : matchings) {
-
-            boolean isAttend = attendanceRepository.findByEventIdAndPrivateId(eventId, matching.getGuideId()).isAttend();
-
-            //출석한 파트너일 경우
-            if(isAttend){
-                // 파트너 조회. 존재하지 않으면 신규 생성
-                Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId())
-                        .orElseGet(() -> Partner.builder()
-                                .viId(matching.getViId())
-                                .guideId(matching.getGuideId())
-                                .contestIds(new HashSet<>())
-                                .trainingIds(new HashSet<>())
-                                .build());
-
-                boolean isTraining = EventType.TRAINING.equals(e.getType());
-                addEventPartner(partner, matching.getEventId(), isTraining);
-            }
-
-        }
-
-    }
-
-    @Transactional
-    public void setAttendGuidePartner(long eventId, User guide){
-        log.info("setAttendGuidePartner - privateId : {}", guide.getPrivateId());
-        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
-        //매칭된 회원 조회
-        Matching matching = matchingRepository.findByEventIdAndGuideId(eventId, guide.getPrivateId());
-
-        if(matching!=null){
-            boolean isAttend = attendanceRepository.findByEventIdAndPrivateId(eventId, matching.getViId()).isAttend();
-
-            //vi가 출석했다면 파트너 추가
-            if(isAttend){
-                // 파트너 조회. 존재하지 않으면 신규 생성
-                Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId())
-                        .orElseGet(() -> Partner.builder()
-                                .viId(matching.getViId())
-                                .guideId(matching.getGuideId())
-                                .contestIds(new HashSet<>())
-                                .trainingIds(new HashSet<>())
-                                .build());
-
-                boolean isTraining = EventType.TRAINING.equals(e.getType());
-                addEventPartner(partner, matching.getEventId(), isTraining);
-            }
-        }
-
-    }
-
-    @Transactional
-    public void setNotAttendViPartnerList(long eventId, User vi){
-        log.info("setNotAttendPartnerList - privateId : {}", vi.getPrivateId());
-        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
-
-        //매칭된 회원 조회
-        List<Matching> matchings = matchingRepository.findAllByEventIdAndViId(eventId, vi.getPrivateId());
-        for (Matching matching : matchings) {
-            // 파트너 조회 후 해당 이벤트가 있으면 삭제.
-            Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId()).orElse(null);
-
-            if(partner!=null){
-                boolean isTraining = EventType.TRAINING.equals(e.getType());
-                removeEventPartner(partner, matching.getEventId(), isTraining);
-            }
-        }
-
-    }
-
-    @Transactional
-    public void setNotAttendGuidePartner(long eventId, User guide){
-        log.info("notAttendGuidePartner - privateId : {}", guide.getPrivateId());
-        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
-
-        Matching matching = matchingRepository.findByEventIdAndGuideId(eventId, guide.getPrivateId());
-        if(matching!=null){
-            // 파트너 조회 후 해당 이벤트가 있으면 삭제.
-            Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId()).orElse(null);
-
-            if(partner!=null){
-                boolean isTraining = EventType.TRAINING.equals(e.getType());
-                removeEventPartner(partner, matching.getEventId(), isTraining);
-            }
-        }
-    }
-
-    @Transactional
-    public void addEventPartner(Partner partner, Long eventId, boolean isTraining) {
-        Set<Long> eventIds = isTraining ? partner.getTrainingIds() : partner.getContestIds();
-
-        if (!eventIds.contains(eventId)) {
-            if (isTraining) {
-                partner.addTraining(eventId);
-                log.info("트레이닝 파트너 저장 - eventId: {}", eventId);
-            } else {
-                partner.addContest(eventId);
-                log.info("대회 파트너 저장 - eventId: {}", eventId);
-            }
-            partnerRepository.save(partner);
-        } else {
-            log.info("파트너에 이미 해당 이벤트가 존재함 - eventId: {}", eventId);
-        }
-
-        partnerRepository.save(partner);
-    }
-
-    @Transactional
-    public void removeEventPartner(Partner partner, Long eventId, boolean isTraining) {
-     Set<Long> eventIds = isTraining ? partner.getTrainingIds() : partner.getContestIds();
-
-     if (eventIds.contains(eventId)) {
-         if(isTraining){
-             partner.removeTraining(eventId);
-             log.info("트레이닝 파트너 삭제 - eventId: {}", eventId);
-         }else{
-             partner.removeContest(eventId);
-             log.info("대회 파트너 삭제 - eventId: {}", eventId);
-         }
-     }else{
-         log.info("파트너에 해당 이벤트가 존재하지 않음 : {}", eventId);
-     }
-
-     partnerRepository.save(partner);
-
     }
 
 }

--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -1,5 +1,6 @@
 package com.guide.run.event.service;
 
+import com.guide.run.attendance.entity.Attendance;
 import com.guide.run.attendance.repository.AttendanceRepository;
 import com.guide.run.event.entity.EventForm;
 import com.guide.run.event.entity.dto.response.form.Form;
@@ -83,10 +84,12 @@ public class EventMatchingService {
         }
 
         //출석 되어 있으면 파트너 반영.
-        boolean isAttend = attendanceRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId()).isAttend();
-        if(isAttend) {
+        Attendance a = attendanceRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId());
+
+        if(a!=null && a.isAttend()){
             partnerService.setAttendGuidePartner(eventId, guide);
         }
+
 
     }
 
@@ -249,11 +252,13 @@ public class EventMatchingService {
                             .build()
             );
 
-            //파트너 반영 추가
-            boolean isAttend = attendanceRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId()).isAttend();
-            if(isAttend) {
+            //출석 되어 있으면 파트너 반영.
+            Attendance a = attendanceRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId());
+
+            if(a!=null && a.isAttend()){
                 partnerService.setAttendGuidePartner(eventId, guide);
             }
+
 
             Optional<UnMatching> findVi = unMatchingRepository.findByPrivateIdAndEventId(vi.getPrivateId(),eventId);
             if(!findVi.isEmpty()){

--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -84,11 +84,7 @@ public class EventMatchingService {
         }
 
         //출석 되어 있으면 파트너 반영.
-        Attendance a = attendanceRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId());
-
-        if(a!=null && a.isAttend()){
-            partnerService.setAttendGuidePartner(eventId, guide);
-        }
+        updatePartnerOnAttendance(eventId, guide);
 
 
     }
@@ -253,11 +249,7 @@ public class EventMatchingService {
             );
 
             //출석 되어 있으면 파트너 반영.
-            Attendance a = attendanceRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId());
-
-            if(a!=null && a.isAttend()){
-                partnerService.setAttendGuidePartner(eventId, guide);
-            }
+            updatePartnerOnAttendance(eventId, guide);
 
 
             Optional<UnMatching> findVi = unMatchingRepository.findByPrivateIdAndEventId(vi.getPrivateId(),eventId);
@@ -270,10 +262,19 @@ public class EventMatchingService {
         return startIdx;
     }
 
+    private void updatePartnerOnAttendance(Long eventId, User guide) {
+        Attendance attendance = attendanceRepository.findByEventIdAndPrivateId(eventId, guide.getPrivateId());
+        if(attendance != null && attendance.isAttend()) {
+            partnerService.setAttendGuidePartner(eventId, guide);
+        }
+        }
+
     /*
     public int autoMatchBetweenTwoGroup(List<Form> vi,List<Form> guide){
 
         return vi.size();
     }
     */
+
+
 }

--- a/run/src/main/java/com/guide/run/partner/service/PartnerService.java
+++ b/run/src/main/java/com/guide/run/partner/service/PartnerService.java
@@ -1,24 +1,38 @@
 package com.guide.run.partner.service;
 
+import com.guide.run.attendance.repository.AttendanceRepository;
+import com.guide.run.event.entity.Event;
+import com.guide.run.event.entity.repository.EventRepository;
+import com.guide.run.event.entity.type.EventType;
 import com.guide.run.global.exception.user.resource.NotExistUserException;
+import com.guide.run.partner.entity.matching.Matching;
+import com.guide.run.partner.entity.matching.repository.MatchingRepository;
+import com.guide.run.partner.entity.partner.Partner;
 import com.guide.run.partner.entity.partner.PartnerLike;
 import com.guide.run.partner.entity.partner.repository.PartnerLikeRepository;
 import com.guide.run.partner.entity.partner.repository.PartnerRepository;
 import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PartnerService {
     private final PartnerRepository partnerRepository;
     private final PartnerLikeRepository partnerLikeRepository;
     private final UserRepository userRepository;
+    private final EventRepository eventRepository;
+    private final MatchingRepository matchingRepository;
+    private final AttendanceRepository attendanceRepository;
 
     @Transactional
     public void partnerLike(String userId, String privateId){
@@ -36,4 +50,139 @@ public class PartnerService {
         }
 
     }
+
+
+    @Transactional
+    public void setAttendViPartnerList(long eventId, User vi){
+        log.info("setAttendPartnerList - privateId : {}", vi.getPrivateId());
+        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
+        //매칭된 회원 조회
+        List<Matching> matchings = matchingRepository.findAllByEventIdAndViId(eventId, vi.getPrivateId());
+        for (Matching matching : matchings) {
+
+            boolean isAttend = attendanceRepository.findByEventIdAndPrivateId(eventId, matching.getGuideId()).isAttend();
+
+            //출석한 파트너일 경우
+            if(isAttend){
+                // 파트너 조회. 존재하지 않으면 신규 생성
+                Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId())
+                        .orElseGet(() -> Partner.builder()
+                                .viId(matching.getViId())
+                                .guideId(matching.getGuideId())
+                                .contestIds(new HashSet<>())
+                                .trainingIds(new HashSet<>())
+                                .build());
+
+                boolean isTraining = EventType.TRAINING.equals(e.getType());
+                addEventPartner(partner, matching.getEventId(), isTraining);
+            }
+
+        }
+
+    }
+
+    @Transactional
+    public void setAttendGuidePartner(long eventId, User guide){
+        log.info("setAttendGuidePartner - privateId : {}", guide.getPrivateId());
+        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
+        //매칭된 회원 조회
+        Matching matching = matchingRepository.findByEventIdAndGuideId(eventId, guide.getPrivateId());
+
+        if(matching!=null){
+            boolean isAttend = attendanceRepository.findByEventIdAndPrivateId(eventId, matching.getViId()).isAttend();
+
+            //vi가 출석했다면 파트너 추가
+            if(isAttend){
+                // 파트너 조회. 존재하지 않으면 신규 생성
+                Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId())
+                        .orElseGet(() -> Partner.builder()
+                                .viId(matching.getViId())
+                                .guideId(matching.getGuideId())
+                                .contestIds(new HashSet<>())
+                                .trainingIds(new HashSet<>())
+                                .build());
+
+                boolean isTraining = EventType.TRAINING.equals(e.getType());
+                addEventPartner(partner, matching.getEventId(), isTraining);
+            }
+        }
+
+    }
+
+    @Transactional
+    public void setNotAttendViPartnerList(long eventId, User vi){
+        log.info("setNotAttendPartnerList - privateId : {}", vi.getPrivateId());
+        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
+
+        //매칭된 회원 조회
+        List<Matching> matchings = matchingRepository.findAllByEventIdAndViId(eventId, vi.getPrivateId());
+        for (Matching matching : matchings) {
+            // 파트너 조회 후 해당 이벤트가 있으면 삭제.
+            Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId()).orElse(null);
+
+            if(partner!=null){
+                boolean isTraining = EventType.TRAINING.equals(e.getType());
+                removeEventPartner(partner, matching.getEventId(), isTraining);
+            }
+        }
+
+    }
+
+    @Transactional
+    public void setNotAttendGuidePartner(long eventId, User guide){
+        log.info("notAttendGuidePartner - privateId : {}", guide.getPrivateId());
+        Event e = eventRepository.findById(eventId).orElseThrow(NotExistUserException::new);
+
+        Matching matching = matchingRepository.findByEventIdAndGuideId(eventId, guide.getPrivateId());
+        if(matching!=null){
+            // 파트너 조회 후 해당 이벤트가 있으면 삭제.
+            Partner partner = partnerRepository.findByViIdAndGuideId(matching.getViId(), matching.getGuideId()).orElse(null);
+
+            if(partner!=null){
+                boolean isTraining = EventType.TRAINING.equals(e.getType());
+                removeEventPartner(partner, matching.getEventId(), isTraining);
+            }
+        }
+    }
+
+    @Transactional
+    public void addEventPartner(Partner partner, Long eventId, boolean isTraining) {
+        Set<Long> eventIds = isTraining ? partner.getTrainingIds() : partner.getContestIds();
+
+        if (!eventIds.contains(eventId)) {
+            if (isTraining) {
+                partner.addTraining(eventId);
+                log.info("트레이닝 파트너 저장 - eventId: {}", eventId);
+            } else {
+                partner.addContest(eventId);
+                log.info("대회 파트너 저장 - eventId: {}", eventId);
+            }
+            partnerRepository.save(partner);
+        } else {
+            log.info("파트너에 이미 해당 이벤트가 존재함 - eventId: {}", eventId);
+        }
+
+        partnerRepository.save(partner);
+    }
+
+    @Transactional
+    public void removeEventPartner(Partner partner, Long eventId, boolean isTraining) {
+        Set<Long> eventIds = isTraining ? partner.getTrainingIds() : partner.getContestIds();
+
+        if (eventIds.contains(eventId)) {
+            if(isTraining){
+                partner.removeTraining(eventId);
+                log.info("트레이닝 파트너 삭제 - eventId: {}", eventId);
+            }else{
+                partner.removeContest(eventId);
+                log.info("대회 파트너 삭제 - eventId: {}", eventId);
+            }
+        }else{
+            log.info("파트너에 해당 이벤트가 존재하지 않음 : {}", eventId);
+        }
+
+        partnerRepository.save(partner);
+
+    }
+
 }

--- a/run/src/main/java/com/guide/run/partner/service/PartnerService.java
+++ b/run/src/main/java/com/guide/run/partner/service/PartnerService.java
@@ -176,10 +176,8 @@ public class PartnerService {
 
     @Transactional
     public void removeEventPartner(Partner partner, Long eventId, boolean isTraining) {
-        Set<Long> eventIds = isTraining ? partner.getTrainingIds() : partner.getContestIds();
-
         try {
-
+            Set<Long> eventIds = isTraining ? partner.getTrainingIds() : partner.getContestIds();
             if (eventIds.contains(eventId)) {
                 if (isTraining) {
                     partner.removeTraining(eventId);

--- a/run/src/main/java/com/guide/run/partner/service/PartnerService.java
+++ b/run/src/main/java/com/guide/run/partner/service/PartnerService.java
@@ -178,20 +178,26 @@ public class PartnerService {
     public void removeEventPartner(Partner partner, Long eventId, boolean isTraining) {
         Set<Long> eventIds = isTraining ? partner.getTrainingIds() : partner.getContestIds();
 
-        if (eventIds.contains(eventId)) {
-            if(isTraining){
-                partner.removeTraining(eventId);
-                log.info("트레이닝 파트너 삭제 - eventId: {}", eventId);
-            }else{
-                partner.removeContest(eventId);
-                log.info("대회 파트너 삭제 - eventId: {}", eventId);
+        try {
+
+            if (eventIds.contains(eventId)) {
+                if (isTraining) {
+                    partner.removeTraining(eventId);
+                    log.info("트레이닝 파트너 삭제 - eventId: {}", eventId);
+                } else {
+                    partner.removeContest(eventId);
+                    log.info("대회 파트너 삭제 - eventId: {}", eventId);
+                }
+            } else {
+                log.info("파트너에 해당 이벤트가 존재하지 않음 : {}", eventId);
             }
-        }else{
-            log.info("파트너에 해당 이벤트가 존재하지 않음 : {}", eventId);
+
+            partnerRepository.save(partner);
+
+        }catch (Exception e){
+            log.error("파트너 저장 중 오류 발생 - eventId: {}, error: {}", eventId, e.getMessage());
+            throw new RuntimeException("파트너 저장 실패", e);
         }
-
-        partnerRepository.save(partner);
-
     }
 
 }

--- a/run/src/main/java/com/guide/run/partner/service/PartnerService.java
+++ b/run/src/main/java/com/guide/run/partner/service/PartnerService.java
@@ -167,7 +167,6 @@ public class PartnerService {
                 partner.addContest(eventId);
                 log.info("대회 파트너 저장 - eventId: {}", eventId);
             }
-            partnerRepository.save(partner);
         } else {
             log.info("파트너에 이미 해당 이벤트가 존재함 - eventId: {}", eventId);
         }

--- a/run/src/main/java/com/guide/run/user/repository/user/UserRepositoryAdminImpl.java
+++ b/run/src/main/java/com/guide/run/user/repository/user/UserRepositoryAdminImpl.java
@@ -45,10 +45,10 @@ public class UserRepositoryAdminImpl implements UserRepositoryAdmin{
     @Override
     public List<UserItem> sortAdminUser(int start, int limit, UserSortCond cond) {
         StringExpression formattedDate = Expressions.stringTemplate("FUNCTION('DATE_FORMAT', {0}, {1})"
-                , user.updatedAt
+                , user.createdAt
                 , ConstantImpl.create("%Y-%m-%d"));
         StringExpression formattedTime = Expressions.stringTemplate("FUNCTION('TIME_FORMAT', {0}, {1})"
-                , user.updatedAt
+                , user.createdAt
                 , ConstantImpl.create("%H:%i:%s"));
 
         List<UserItem> userItems = queryFactory
@@ -93,10 +93,10 @@ public class UserRepositoryAdminImpl implements UserRepositoryAdmin{
     @Override
     public List<UserItem> searchAdminUser(int start, int limit, UserSortCond cond, String text) {
         StringExpression formattedDate = Expressions.stringTemplate("FUNCTION('DATE_FORMAT', {0}, {1})"
-                , user.updatedAt
+                , user.createdAt
                 , ConstantImpl.create("%Y-%m-%d"));
         StringExpression formattedTime = Expressions.stringTemplate("FUNCTION('TIME_FORMAT', {0}, {1})"
-                , user.updatedAt
+                , user.createdAt
                 , ConstantImpl.create("%H:%i:%s"));
 
         List<UserItem> userItems = queryFactory
@@ -206,7 +206,7 @@ public class UserRepositoryAdminImpl implements UserRepositoryAdmin{
 
 
         if (cond.getTime()==0) {
-            orderSpecifiers.add(new OrderSpecifier(Order.DESC, user.updatedAt));
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, user.createdAt));
         }
 
         if (cond.getType()==0) {
@@ -230,7 +230,7 @@ public class UserRepositoryAdminImpl implements UserRepositoryAdmin{
         }
 
         if (cond.getTime()==1) {
-            orderSpecifiers.add(new OrderSpecifier(Order.ASC, user.updatedAt));
+            orderSpecifiers.add(new OrderSpecifier(Order.ASC, user.createdAt));
         }
 
         if (cond.getGender()==1) {
@@ -246,7 +246,7 @@ public class UserRepositoryAdminImpl implements UserRepositoryAdmin{
 
         if (cond.getTime()==2 && cond.getApproval()==2 && cond.getType()==2
                 && cond.getName_team()==2&& cond.getGender()==2) {
-            orderSpecifiers.add(new OrderSpecifier(Order.DESC, user.updatedAt));
+            orderSpecifiers.add(new OrderSpecifier(Order.DESC, user.createdAt));
         }
 
         return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);


### PR DESCRIPTION
<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 이벤트 참가 시 파트너 출석 관리가 중앙화되어, 참가자의 상황에 맞춰 파트너 정보가 일관되게 업데이트됩니다.
  - 파트너의 출석 상태를 관리하는 새로운 메소드가 추가되었습니다.
  - 이벤트 및 사용자 기록의 정렬 기준이 업데이트 날짜에서 생성 날짜로 변경되었습니다.

- **버그 수정**
  - 사용자 및 이벤트의 정렬 및 검색 기능에서 업데이트 날짜 대신 생성 날짜를 기준으로 변경하여 일관성을 개선했습니다.

- **리팩토링**
  - 기존의 분산된 파트너 관리 로직을 하나의 서비스로 통합하여 이벤트 매칭 및 참가 처리 과정이 간소화되었으며, 가이드 출석 여부에 따른 처리 효율이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->