### PR TITLE
fix : 매칭 취소 시 파트너 삭제 안되는 에러 수정 + 출석 인원 반영 시 기존(서비스 배포 전) 이벤트는 제외하도록 변경

### DIFF
--- a/run/src/main/java/com/guide/run/attendance/service/AttendService.java
+++ b/run/src/main/java/com/guide/run/attendance/service/AttendService.java
@@ -28,7 +28,7 @@ public class AttendService {
 
     @Transactional
     public void countAttendUser(long eventId, boolean isAttend) {
-        if(eventId<=31){
+        if(eventId<=44){
             return;
         }
 

--- a/run/src/main/java/com/guide/run/attendance/service/AttendService.java
+++ b/run/src/main/java/com/guide/run/attendance/service/AttendService.java
@@ -28,8 +28,14 @@ public class AttendService {
 
     @Transactional
     public void countAttendUser(long eventId, boolean isAttend) {
+        if(eventId<=31){
+            return;
+        }
+
         int viCnt = 0;
         int guideCnt = 0;
+
+
         Event event = eventRepository.findById(eventId).orElseThrow(NotExistEventException::new);
         List<Attendance> attendances = attendanceRepository.findAllByEventIdAndIsAttend(eventId, isAttend);
         for(Attendance attendance : attendances) {

--- a/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventMatchingService.java
@@ -102,6 +102,9 @@ public class EventMatchingService {
 
         if(user.getType()==UserType.VI){
             List<Matching> allMatching = matchingRepository.findAllByEventIdAndViId(eventId, privateId);
+            //vi 파트너 삭제 추가
+            partnerService.setNotAttendViPartnerList(eventId, user);
+
             for(Matching m : allMatching){
                 matchingRepository.delete(m);
                 unMatchingRepository.save(
@@ -119,11 +122,14 @@ public class EventMatchingService {
                             .build()
             );
 
-            //vi 파트너 삭제 추가
-            partnerService.setNotAttendViPartnerList(eventId, user);
+
 
         }else{
             Matching m = matchingRepository.findByEventIdAndGuideId(eventId, privateId);
+
+            //파트너 삭제 추가
+            partnerService.setNotAttendGuidePartner(eventId, user);
+
             matchingRepository.delete(m);
             unMatchingRepository.save(
                     UnMatching.builder()
@@ -132,9 +138,6 @@ public class EventMatchingService {
                             .build()
             );
             matchingRepository.flush();
-
-            //파트너 삭제 추가
-            partnerService.setNotAttendGuidePartner(eventId, user);
 
             if(matchingRepository.findAllByEventIdAndViId(eventId,m.getViId()).size()==0){
                 unMatchingRepository.save(

--- a/run/src/main/java/com/guide/run/partner/entity/partner/repository/PartnerRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/partner/entity/partner/repository/PartnerRepositoryImpl.java
@@ -139,7 +139,6 @@ public class PartnerRepositoryImpl implements PartnerRepositoryCustom{
                         getPartnerId(type),
                         (user.name.contains(text)
                                 .or(user.recordDegree.toUpperCase().contains(text.toUpperCase()))
-                                //todo : 검색 조건 추가 필요
                                 )
                 )
                 .offset(start)


### PR DESCRIPTION
<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩터**
	- 특정 이벤트에 대해 불필요한 처리를 방지하도록 이벤트 ID 기준 추가 검증으로 작업 흐름을 개선했습니다.
	- 파트너 삭제 순서를 최적화해, 관련 참석 상태가 정확하게 업데이트된 후 삭제가 진행되도록 개선했습니다.
- **잡무**
	- 불필요한 내부 주석을 제거하여 코드 정리를 수행했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->