### PR TITLE
feat: 이벤트 신청서 조회 시 어드민일 경우 전화번호 조회 추가

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventFormController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventFormController.java
@@ -45,8 +45,8 @@ public class EventFormController {
     }
     @GetMapping("/{eventId}/forms/all")
     public ResponseEntity<GetAllForms> getAllForms(@PathVariable("eventId") Long eventId, HttpServletRequest request){
-        jwtProvider.extractUserId(request);
-        return ResponseEntity.ok().body(eventFormService.getAllForms(eventId));
+        String privateId = jwtProvider.extractUserId(request);
+        return ResponseEntity.ok().body(eventFormService.getAllForms(eventId,privateId));
     }
     @DeleteMapping("/{eventId}/form")
     public ResponseEntity<String> deleteForm(@PathVariable("eventId") Long eventId,

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/form/FormWithPhone.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/form/FormWithPhone.java
@@ -1,0 +1,27 @@
+package com.guide.run.event.entity.dto.response.form;
+
+import com.guide.run.user.entity.type.UserType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class FormWithPhone {
+    private String userId;
+    private UserType type;
+    private String applyRecord;
+    private String name;
+    private String recordDegree;
+    private String phone;
+
+    public FormWithPhone(String userId, UserType type, String applyRecord, String name, String recordDegree) {
+        this.userId = userId;
+        this.type = type;
+        this.applyRecord = applyRecord;
+        this.name = name;
+        this.recordDegree = recordDegree;
+        this.phone = null;
+    }
+}

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/form/GetAllForms.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/form/GetAllForms.java
@@ -10,6 +10,6 @@ import java.util.List;
 @Getter
 @Builder
 public class GetAllForms {
-    private List<Form> vi;
-    private List<Form> guide;
+    private List<FormWithPhone> vi;
+    private List<FormWithPhone> guide;
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepositoryCustom.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity.repository;
 
 import com.guide.run.event.entity.dto.response.form.Form;
+import com.guide.run.event.entity.dto.response.form.FormWithPhone;
 import com.guide.run.user.entity.type.UserType;
 
 import java.util.List;
@@ -8,4 +9,7 @@ import java.util.List;
 public interface EventFormRepositoryCustom {
     List<Form> findAllEventIdAndUserType(Long eventId, UserType userType);
     List<Form> findAllEventIdAndUserTypeAndHopeTeam(Long eventId, UserType userType,String hopeTeam);
+
+    List<FormWithPhone> findAllFormsWithPhone(Long eventId, UserType userType);
+    List<FormWithPhone> findAllFormsWithoutPhone(Long eventId, UserType userType);
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.guide.run.event.entity.repository;
 
 import com.guide.run.event.entity.QEventForm;
 import com.guide.run.event.entity.dto.response.form.Form;
+import com.guide.run.event.entity.dto.response.form.FormWithPhone;
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.QUser;
 import com.querydsl.core.types.Projections;
@@ -44,6 +45,35 @@ public class EventFormRepositoryImpl implements EventFormRepositoryCustom{
                 .from(eventForm)
                 .join(user).on(eventForm.privateId.eq(user.privateId).and(eventForm.eventId.eq(eventId)))
                 .where(eventForm.eventId.eq(eventId).and(user.type.eq(userType)).and(eventForm.hopeTeam.eq(hopeTeam)))
+                .fetch();
+    }
+
+    @Override
+    public List<FormWithPhone> findAllFormsWithPhone(Long eventId, UserType userType) {
+        return queryFactory.select(Projections.constructor(FormWithPhone.class,
+                        user.userId.as("userId"),
+                        user.type.as("type"),
+                        eventForm.hopeTeam.as("applyRecord"),
+                        user.name.as("name"),
+                        user.recordDegree.as("recordDegree"),
+                        user.phoneNumber.as("phone")))
+                .from(eventForm)
+                .join(user).on(eventForm.privateId.eq(user.privateId).and(eventForm.eventId.eq(eventId)))
+                .where(eventForm.eventId.eq(eventId).and(user.type.eq(userType)))
+                .fetch();
+    }
+
+    @Override
+    public List<FormWithPhone> findAllFormsWithoutPhone(Long eventId, UserType userType) {
+        return queryFactory.select(Projections.constructor(FormWithPhone.class,
+                        user.userId.as("userId"),
+                        user.type.as("type"),
+                        eventForm.hopeTeam.as("applyRecord"),
+                        user.name.as("name"),
+                        user.recordDegree.as("recordDegree")))
+                .from(eventForm)
+                .join(user).on(eventForm.privateId.eq(user.privateId).and(eventForm.eventId.eq(eventId)))
+                .where(eventForm.eventId.eq(eventId).and(user.type.eq(userType)))
                 .fetch();
     }
 }

--- a/run/src/main/java/com/guide/run/event/service/EventFormService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventFormService.java
@@ -18,6 +18,7 @@ import com.guide.run.partner.entity.matching.repository.MatchingRepository;
 import com.guide.run.partner.entity.matching.repository.UnMatchingRepository;
 import com.guide.run.attendance.entity.Attendance;
 import com.guide.run.attendance.repository.AttendanceRepository;
+import com.guide.run.user.entity.type.Role;
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.User;
 import com.guide.run.user.repository.user.UserRepository;
@@ -112,11 +113,19 @@ public class EventFormService {
                 .build();
     }
 
-    public GetAllForms getAllForms(Long eventId) {
-        return GetAllForms.builder()
-                .vi(eventFormRepository.findAllEventIdAndUserType(eventId, UserType.VI))
-                .guide(eventFormRepository.findAllEventIdAndUserType(eventId,UserType.GUIDE))
-                .build();
+    public GetAllForms getAllForms(Long eventId, String privateId) {
+        User user = userRepository.findUserByPrivateId(privateId).orElseThrow(NotExistUserException::new);
+        if(user.getRole().equals(Role.ROLE_ADMIN)){
+            return (GetAllForms.builder()
+                    .vi(eventFormRepository.findAllFormsWithPhone(eventId, UserType.VI))
+                    .guide(eventFormRepository.findAllFormsWithPhone(eventId,UserType.GUIDE))
+                    .build());
+        }else{
+            return (GetAllForms.builder()
+                    .vi(eventFormRepository.findAllFormsWithoutPhone(eventId, UserType.VI))
+                    .guide(eventFormRepository.findAllFormsWithoutPhone(eventId,UserType.GUIDE))
+                    .build());
+        }
     }
 
     @Transactional


### PR DESCRIPTION
<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [x] Feat
- [ ] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
이벤트 신청서 조회 시 어드민일 경우 전화번호 조회 추가


## **변경 내용**
FormWithPhone 리스폰스 추가해서 따로 로직 만들었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자는 이벤트 참가자 목록 조회 시 전화번호 정보를 포함하여 확인할 수 있습니다.
  * 일반 사용자는 전화번호 정보가 제외된 참가자 목록만 조회할 수 있습니다.

* **버그 수정**
  * 사용자 권한에 따라 이벤트 참가자 정보 노출 범위가 적절히 제한됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->