### PR TITLE
fix : 이벤트 조회,상세 조회,팝업 조회 수정

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventGetController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventGetController.java
@@ -4,6 +4,7 @@ package com.guide.run.event.controller;
 import com.guide.run.event.entity.dto.response.get.AllEventResponse;
 import com.guide.run.event.entity.dto.response.get.Count;
 import com.guide.run.event.entity.dto.response.get.MyEventResponse;
+import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.event.service.EventGetService;
@@ -45,6 +46,7 @@ public class EventGetController {
     public ResponseEntity<Count> getAllEventListCount(@RequestParam("sort") String sort,
                                                       @RequestParam("type") EventType type,
                                                       @RequestParam("kind") EventRecruitStatus kind,
+                                                      @RequestParam("cityName") CityName cityName,
                                                       HttpServletRequest request){
         if(sort.equals("UPCOMING") || sort.equals("END") || sort.equals("MY")){}
         else throw new NotValidSortException();
@@ -55,13 +57,14 @@ public class EventGetController {
         else throw new NotValidKindException();
         String userId = jwtProvider.extractUserId(request);
         return ResponseEntity.status(200).
-                body(Count.builder().count(eventGetService.getAllEventListCount(sort,type,kind,userId)).build());
+                body(Count.builder().count(eventGetService.getAllEventListCount(sort,type,kind,userId,cityName)).build());
     }
 
     @GetMapping("/all")
     public ResponseEntity<AllEventResponse> getAllEventList(@RequestParam("sort") String sort,
                                                             @RequestParam("type") EventType type,
                                                             @RequestParam("kind") EventRecruitStatus kind,
+                                                            @RequestParam("cityName") CityName cityName,
                                                             @RequestParam("limit") int limit,
                                                             @RequestParam("start") int start,
                                                             HttpServletRequest request){
@@ -74,6 +77,6 @@ public class EventGetController {
         else throw new NotValidKindException();
         String userId = jwtProvider.extractUserId(request);
         return ResponseEntity.status(200).
-                body(eventGetService.getAllEventList(limit,start,sort,type,kind,userId));
+                body(eventGetService.getAllEventList(limit,start,sort,type,kind,userId,cityName));
     }
 }

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/EventPopUpResponse.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/EventPopUpResponse.java
@@ -1,9 +1,6 @@
 package com.guide.run.event.entity.dto.response;
 
-import com.guide.run.event.entity.type.EventCategory;
-import com.guide.run.event.entity.type.EventRecruitStatus;
-import com.guide.run.event.entity.type.EventStatus;
-import com.guide.run.event.entity.type.EventType;
+import com.guide.run.event.entity.type.*;
 import com.guide.run.user.entity.type.UserType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -46,6 +43,9 @@ public class EventPopUpResponse {
 
         private EventStatus status; //이벤트 status
         private EventCategory eventCategory;
+
+        //지역
+        private CityName cityName;
 
 
         public void setPartner(Boolean isApply, Boolean hasPartner, List<EventPopUpPartner> partner){

--- a/run/src/main/java/com/guide/run/event/entity/dto/response/get/DetailEvent.java
+++ b/run/src/main/java/com/guide/run/event/entity/dto/response/get/DetailEvent.java
@@ -2,10 +2,7 @@ package com.guide.run.event.entity.dto.response.get;
 
 
 import com.guide.run.event.entity.dto.response.EventPopUpPartner;
-import com.guide.run.event.entity.type.EventCategory;
-import com.guide.run.event.entity.type.EventRecruitStatus;
-import com.guide.run.event.entity.type.EventStatus;
-import com.guide.run.event.entity.type.EventType;
+import com.guide.run.event.entity.type.*;
 import com.guide.run.user.entity.type.UserType;
 import com.guide.run.user.entity.user.User;
 import lombok.AllArgsConstructor;
@@ -52,5 +49,8 @@ public class DetailEvent {
     private Boolean checkOrganizer;
     private EventStatus status;
     private EventCategory eventCategory;
+
+    //지역
+    private CityName cityName;
 
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepository.java
@@ -1,6 +1,7 @@
 package com.guide.run.event.entity.repository;
 
 import com.guide.run.event.entity.EventForm;
+import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import org.springframework.data.domain.Page;
@@ -18,8 +19,5 @@ public interface EventFormRepository extends JpaRepository <EventForm,Long> ,Eve
     void deleteAllByEventId(Long eventId);
     void deleteAllByPrivateId(String privateId);
     List<EventForm> findAllByEventId(Long eventId);
-
-    long countByPrivateId(String privateId);
-
 
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
@@ -3,6 +3,7 @@ package com.guide.run.event.entity.repository;
 import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.dto.response.get.MyEventDday;
 import com.guide.run.event.entity.dto.response.get.MyEventDdayResponse;
+import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import org.springframework.data.domain.Page;
@@ -19,20 +20,16 @@ public interface EventRepository extends JpaRepository<Event,Long>, EventReposit
     List<Event> findAllByNameContainingOrContentContaining(String name,String content);
     Page<Event> findAllByNameContainingOrContentContaining(String name,String content,Pageable pageable);
 
-    List<Event> findAllByRecruitStatusNot(EventRecruitStatus eventRecruitStatus);
-
-    List<Event> findAllByTypeAndRecruitStatusNot(EventType type, EventRecruitStatus eventRecruitStatus);
-
-    List<Event> findAllByRecruitStatus(EventRecruitStatus eventRecruitStatus);
-
-    List<Event> findAllByTypeAndRecruitStatus(EventType type, EventRecruitStatus eventRecruitStatus);
-
     long countByRecruitStatusNotAndIsApprove(EventRecruitStatus eventRecruitStatus, boolean isApprove);
 
-    long countByRecruitStatusAndIsApprove(EventRecruitStatus kind, boolean isApprove);
+    long countByRecruitStatusNotAndIsApproveAndCityName(EventRecruitStatus eventRecruitStatus, boolean isApprove, CityName cityName);
+
+    long countByRecruitStatusAndIsApproveAndCityName(EventRecruitStatus kind, boolean isApprove, CityName cityName);
 
     long countByTypeAndRecruitStatusNotAndIsApprove(EventType type, EventRecruitStatus eventRecruitStatus, boolean isApprove);
 
-    long countByTypeAndRecruitStatusAndIsApprove(EventType type, EventRecruitStatus kind, boolean isApprove);
+    long countByTypeAndRecruitStatusNotAndIsApproveAndCityName(EventType type, EventRecruitStatus eventRecruitStatus, boolean isApprove,CityName cityName);
+
+    long countByTypeAndRecruitStatusAndIsApproveAndCityName(EventType type, EventRecruitStatus kind, boolean isApprove,CityName cityName);
     List<Event> findAllByOrganizer(String organizer);
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryCustom.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.guide.run.event.entity.Event;
 import com.guide.run.event.entity.dto.response.calender.MyEventOfDayOfCalendar;
 import com.guide.run.event.entity.dto.response.calender.MyEventOfMonth;
 import com.guide.run.event.entity.dto.response.get.*;
+import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.user.entity.type.UserType;
@@ -16,13 +17,15 @@ public interface EventRepositoryCustom {
     List<MyEvent> findMyEventByYear(String privateId, int year, EventRecruitStatus eventRecruitStatus);
     List<MyEventOfMonth> findMyEventsOfMonth(LocalDateTime startTime, LocalDateTime endTime,String privateId);
     List<MyEventOfDayOfCalendar> findMyEventsOfDay(LocalDateTime startTime,LocalDateTime endTime,String privateId);
-    long getAllMyEventListCount(EventType eventType,EventRecruitStatus eventRecruitStatus,String privateId);
-    List<AllEvent> getAllMyEventList(int limit,int start,EventType eventType,EventRecruitStatus eventRecruitStatus,String privateId);
+    long getAllMyEventListCount(EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName);
+    List<AllEvent> getAllMyEventList(int limit,int start,EventType eventType,EventRecruitStatus eventRecruitStatus,String privateId, CityName cityName);
     List<MyEventDday> getMyEventDday(String userId);
 
     List<Event> getSchedulerEvent();
     List<Event> getSchedulerRecruit();
 
-    List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus);
-    List<AllEvent> upcomingGetAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus);
+    List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
+    List<AllEvent> upcomingGetAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, CityName cityName);
+
+    long countByPrivateIdAndCityName(String privateId, CityName cityName);
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.guide.run.event.entity.dto.response.calender.MyEventOfMonth;
 import com.guide.run.event.entity.dto.response.get.AllEvent;
 import com.guide.run.event.entity.dto.response.get.MyEvent;
 import com.guide.run.event.entity.dto.response.get.MyEventDday;
+import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventStatus;
 import com.guide.run.event.entity.type.EventType;
@@ -124,18 +125,20 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
     }
 
     @Override
-    public long getAllMyEventListCount(EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId) {
+    public long getAllMyEventListCount(EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName) {
         return queryFactory.select(event.count())
                 .from(event)
                 .join(eventForm).on(eventForm.eventId.eq(event.id))
                 .where(checkByKind(eventRecruitStatus).and(checkByType(eventType)).and(event.isApprove.eq(true))
                         .and(eventForm.privateId.eq(privateId))
-                        .and(eventForm.eventId.eq(event.id)))
+                        .and(eventForm.eventId.eq(event.id))
+                        .and(event.cityName.eq(event.cityName))
+                )
                 .fetchOne();
     }
 
     @Override
-    public List<AllEvent> getAllMyEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId) {
+    public List<AllEvent> getAllMyEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus, String privateId, CityName cityName) {
         return queryFactory.select(Projections.constructor(AllEvent.class,
                 event.id.as("eventId"),
                 event.type.as("eventType"),
@@ -146,7 +149,9 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .join(eventForm).on(eventForm.eventId.eq(event.id))
                 .where(checkByKind(eventRecruitStatus).and(checkByType(eventType)).and(event.isApprove.eq(true))
                         .and(eventForm.privateId.eq(privateId))
-                        .and(eventForm.eventId.eq(event.id)))
+                        .and(eventForm.eventId.eq(event.id))
+                        .and(event.cityName.eq(event.cityName))
+                )
                 .orderBy(event.startTime.desc())
                 .offset(start)
                 .limit(limit)
@@ -188,7 +193,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
     }
 
     @Override
-    public List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus) {
+    public List<AllEvent> getAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus,CityName cityName) {
         return queryFactory.select(Projections.constructor(AllEvent.class,
                         event.id.as("eventId"),
                         event.type.as("eventType"),
@@ -196,14 +201,18 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.startTime.as("date"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
-                .where(checkByKind(eventRecruitStatus).and(checkByType(eventType)).and(event.isApprove.eq(true)))
+                .where(checkByKind(eventRecruitStatus)
+                        .and(checkByType(eventType))
+                        .and(event.isApprove.eq(true))
+                        .and(event.cityName.eq(event.cityName))
+                )
                 .orderBy(event.startTime.desc())
                 .offset(start)
                 .limit(limit)
                 .fetch();
     }
     @Override
-    public List<AllEvent> upcomingGetAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus) {
+    public List<AllEvent> upcomingGetAllEventList(int limit, int start, EventType eventType, EventRecruitStatus eventRecruitStatus,CityName cityName) {
         return queryFactory.select(Projections.constructor(AllEvent.class,
                         event.id.as("eventId"),
                         event.type.as("eventType"),
@@ -211,13 +220,26 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                         event.startTime.as("date"),
                         event.recruitStatus.as("recruitStatus")))
                 .from(event)
-                .where(checkByKind(eventRecruitStatus).and(checkByType(eventType)).and(event.isApprove.eq(true)))
+                .where(checkByKind(eventRecruitStatus)
+                        .and(checkByType(eventType))
+                        .and(event.isApprove.eq(true))
+                        .and(event.cityName.eq(event.cityName))
+                )
                 .orderBy(event.startTime.asc())
                 .offset(start)
                 .limit(limit)
                 .fetch();
     }
 
+    @Override
+    public long countByPrivateIdAndCityName(String privateId, CityName cityName) {
+        return queryFactory
+                .select(eventForm.count())
+                .from(eventForm)
+                .join(event).on(eventForm.eventId.eq(event.id))
+                .where(event.cityName.eq(cityName))
+                .fetchOne();
+    }
 
 
     private BooleanBuilder checkByKind(EventRecruitStatus kind){

--- a/run/src/main/java/com/guide/run/event/service/EventGetService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventGetService.java
@@ -6,6 +6,7 @@ import com.guide.run.event.entity.dto.response.get.*;
 import com.guide.run.event.entity.repository.EventFormRepository;
 import com.guide.run.event.entity.repository.EventRepository;
 import com.guide.run.event.entity.repository.EventRepositoryImpl;
+import com.guide.run.event.entity.type.CityName;
 import com.guide.run.event.entity.type.EventRecruitStatus;
 import com.guide.run.event.entity.type.EventType;
 import com.guide.run.global.exception.event.logic.NotValidKindException;
@@ -44,43 +45,43 @@ public class EventGetService {
        return MyEventResponse.builder().items(myEvents).build();
     }
 
-    public long getAllEventListCount(String sort, EventType type, EventRecruitStatus kind, String privateId){
+    public long getAllEventListCount(String sort, EventType type, EventRecruitStatus kind, String privateId, CityName cityName){
         if(sort.equals("UPCOMING")){
             if(type.equals(TOTAL)){
                 if(kind.equals(RECRUIT_ALL)){
-                    return eventRepository.countByRecruitStatusNotAndIsApprove(RECRUIT_END,true);
+                    return eventRepository.countByRecruitStatusNotAndIsApproveAndCityName(RECRUIT_END,true,cityName);
                 }
                 else{
-                    return eventRepository.countByRecruitStatusAndIsApprove(kind,true);
+                    return eventRepository.countByRecruitStatusAndIsApproveAndCityName(kind,true,cityName);
                 }
             }else{
                 if(kind.equals(RECRUIT_ALL)){
-                    return eventRepository.countByTypeAndRecruitStatusNotAndIsApprove(type, RECRUIT_END,true);
+                    return eventRepository.countByTypeAndRecruitStatusNotAndIsApproveAndCityName(type, RECRUIT_END,true,cityName);
                 }
                 else{
-                    return eventRepository.countByTypeAndRecruitStatusAndIsApprove(type,kind,true);
+                    return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type,kind,true,cityName);
                 }
             }
         }else if(sort.equals("END")){
             if(type.equals(TOTAL)){
-                return eventRepository.countByRecruitStatusAndIsApprove(RECRUIT_END,true);
+                return eventRepository.countByRecruitStatusAndIsApproveAndCityName(RECRUIT_END,true,cityName);
             }else{
-                return eventRepository.countByTypeAndRecruitStatusAndIsApprove(type, RECRUIT_END,true);
+                return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type, RECRUIT_END,true,cityName);
             }
         }else{
             if(type.equals(TOTAL)){
                 if(kind.equals(RECRUIT_ALL)){
-                    return eventFormRepository.countByPrivateId(privateId);
+                    return eventRepository.countByPrivateIdAndCityName(privateId,cityName);
                 }
                 else{
-                    return eventRepository.getAllMyEventListCount(null,kind,privateId);
+                    return eventRepository.getAllMyEventListCount(null,kind,privateId,cityName);
                 }
             }else{
                 if(kind.equals(RECRUIT_ALL)){
-                    return eventRepository.getAllMyEventListCount(type, null,privateId);
+                    return eventRepository.getAllMyEventListCount(type, null,privateId,cityName);
                 }
                 else{
-                    return eventRepository.getAllMyEventListCount(type,kind,privateId);
+                    return eventRepository.getAllMyEventListCount(type,kind,privateId,cityName);
                 }
             }
         }
@@ -91,46 +92,47 @@ public class EventGetService {
                                             String sort,
                                             EventType type,
                                             EventRecruitStatus kind,
-                                            String userId) {
+                                            String userId,
+                                            CityName cityName) {
         List<AllEvent> allEvents = new ArrayList<>();
         if(sort.equals("UPCOMING")){
             if(kind.equals(RECRUIT_END))
                 throw new NotValidKindException();
             if(type.equals(TOTAL)){
                 if(kind.equals(RECRUIT_ALL)){
-                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,null,RECRUIT_ALL);
+                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,null,RECRUIT_ALL,cityName);
                 }
                 else{
-                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,null,kind);
+                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,null,kind,cityName);
                 }
             }else{
                 if(kind.equals(RECRUIT_ALL)){
-                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,type,RECRUIT_ALL);
+                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,type,RECRUIT_ALL,cityName);
                 }
                 else{
-                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,type,kind);
+                    allEvents = eventRepository.upcomingGetAllEventList(limit,start,type,kind,cityName);
                 }
             }
         }else if(sort.equals("END")){
             if(type.equals(TOTAL)){
-                allEvents = eventRepository.getAllEventList(limit,start,null, RECRUIT_END);
+                allEvents = eventRepository.getAllEventList(limit,start,null, RECRUIT_END,cityName);
             }else{
-                allEvents = eventRepository.getAllEventList(limit,start,type,RECRUIT_END);
+                allEvents = eventRepository.getAllEventList(limit,start,type,RECRUIT_END,cityName);
             }
         }else{
             if(type.equals(TOTAL)){
                 if(kind.equals(RECRUIT_ALL)){
-                    allEvents = eventRepository.getAllMyEventList(limit,start,null,null,userId);
+                    allEvents = eventRepository.getAllMyEventList(limit,start,null,null,userId,cityName);
                 }
                 else{
-                    allEvents = eventRepository.getAllMyEventList(limit,start,null,kind,userId);
+                    allEvents = eventRepository.getAllMyEventList(limit,start,null,kind,userId,cityName);
                 }
             }else{
                 if(kind.equals(RECRUIT_ALL)){
-                    allEvents = eventRepository.getAllMyEventList(limit,start,type,null,userId);
+                    allEvents = eventRepository.getAllMyEventList(limit,start,type,null,userId,cityName);
                 }
                 else{
-                    allEvents = eventRepository.getAllMyEventList(limit,start,type,kind,userId);
+                    allEvents = eventRepository.getAllMyEventList(limit,start,type,kind,userId,cityName);
                 }
             }
         }

--- a/run/src/main/java/com/guide/run/event/service/EventService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventService.java
@@ -322,6 +322,7 @@ public class EventService {
                 .hasPartner(false) //파트너 존재 여부
                 .partner(partnerList)
                 .eventCategory(event.getEventCategory())
+                .cityName(event.getCityName())
                 .build();
 
         //매칭 여부로 파트너 정보 추가
@@ -429,7 +430,8 @@ public class EventService {
                     .details(event.getContent())
                     .checkOrganizer(isCheckOrganizer)
                     .status(event.getStatus())
-                    .eventCategory(event.getEventCategory()).build();
+                    .eventCategory(event.getEventCategory())
+                    .cityName(event.getCityName()).build();
         }
         //신청한 경우
         else{
@@ -463,7 +465,8 @@ public class EventService {
                             .details(event.getContent())
                             .checkOrganizer(isCheckOrganizer)
                             .status(event.getStatus())
-                            .eventCategory(event.getEventCategory()).build();
+                            .eventCategory(event.getEventCategory())
+                            .cityName(event.getCityName()).build();
                 }
                 else{
                     User vi = userRepository.findUserByPrivateId(matching.getViId()).orElseThrow(NotExistUserException::new);
@@ -499,7 +502,8 @@ public class EventService {
                             .details(event.getContent())
                             .checkOrganizer(isCheckOrganizer)
                             .status(event.getStatus())
-                            .eventCategory(event.getEventCategory()).build();
+                            .eventCategory(event.getEventCategory())
+                            .cityName(event.getCityName()).build();
                 }
             }else{
                 List<Matching> matchingList = matchingRepository.findAllByEventIdAndViId(eventId, user.getPrivateId());
@@ -531,7 +535,8 @@ public class EventService {
                             .details(event.getContent())
                             .checkOrganizer(isCheckOrganizer)
                             .status(event.getStatus())
-                            .eventCategory(event.getEventCategory()).build();
+                            .eventCategory(event.getEventCategory())
+                            .cityName(event.getCityName()).build();
                 }
                 else{
                     for(Matching m : matchingList){
@@ -569,7 +574,8 @@ public class EventService {
                             .details(event.getContent())
                             .checkOrganizer(isCheckOrganizer)
                             .status(event.getStatus())
-                            .eventCategory(event.getEventCategory()).build();
+                            .eventCategory(event.getEventCategory())
+                            .cityName(event.getCityName()).build();
                 }
             }
         }


### PR DESCRIPTION
상세조회,팝업 조회 응답값에 cityName(지역명) 추가
이벤트 조회시 필터에 cityName을 추가하여 서울,부산 구분 가능하게 변경

<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [ O] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
이벤트 조회,상세조회,팝업 조회 수정

## **변경 내용**
상세 조회,팝업 조회 응답값에 지역명(cityName)추가
이벤트 조회의 경우 필터에 cityName을 추가하여 서울,부산 지역 필터로 검색 가능하게 변경

## **관련 이슈**
Resolves: #123 ...(해결한 이슈 번호)

See also: #45 #6 ...(참고 이슈 번호)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 이벤트 목록/카운트에 도시별 필터링이 추가되었습니다. 요청 파라미터 cityName을 통해 특정 도시의 이벤트만 조회할 수 있습니다. 전체 목록, 예정/종료, 내 이벤트 목록 등 모든 목록 조회에 적용됩니다.
  * 이벤트 팝업과 상세 보기 응답에 도시 정보가 표시됩니다. 관련 화면에서 이벤트의 도시를 즉시 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->