### PR TITLE
fix : 이벤트 조회 수정

### DIFF
--- a/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventFormRepository.java
@@ -20,4 +20,5 @@ public interface EventFormRepository extends JpaRepository <EventForm,Long> ,Eve
     void deleteAllByPrivateId(String privateId);
     List<EventForm> findAllByEventId(Long eventId);
 
+    long countByPrivateId(String privateId);
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepository.java
@@ -32,4 +32,9 @@ public interface EventRepository extends JpaRepository<Event,Long>, EventReposit
 
     long countByTypeAndRecruitStatusAndIsApproveAndCityName(EventType type, EventRecruitStatus kind, boolean isApprove,CityName cityName);
     List<Event> findAllByOrganizer(String organizer);
+
+    long countByRecruitStatusAndIsApprove(EventRecruitStatus kind, boolean isApprove);
+
+    long countByTypeAndRecruitStatusAndIsApprove(EventType type, EventRecruitStatus kind, boolean isApprove);
+
 }

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -132,7 +132,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .where(checkByKind(eventRecruitStatus).and(checkByType(eventType)).and(event.isApprove.eq(true))
                         .and(eventForm.privateId.eq(privateId))
                         .and(eventForm.eventId.eq(event.id))
-                        .and(event.cityName.eq(event.cityName))
+                        .and(checkByCityName(cityName))
                 )
                 .fetchOne();
     }
@@ -150,7 +150,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .where(checkByKind(eventRecruitStatus).and(checkByType(eventType)).and(event.isApprove.eq(true))
                         .and(eventForm.privateId.eq(privateId))
                         .and(eventForm.eventId.eq(event.id))
-                        .and(event.cityName.eq(event.cityName))
+                        .and(checkByCityName(cityName))
                 )
                 .orderBy(event.startTime.desc())
                 .offset(start)
@@ -204,7 +204,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .where(checkByKind(eventRecruitStatus)
                         .and(checkByType(eventType))
                         .and(event.isApprove.eq(true))
-                        .and(event.cityName.eq(event.cityName))
+                        .and(checkByCityName(cityName))
                 )
                 .orderBy(event.startTime.desc())
                 .offset(start)
@@ -223,7 +223,7 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .where(checkByKind(eventRecruitStatus)
                         .and(checkByType(eventType))
                         .and(event.isApprove.eq(true))
-                        .and(event.cityName.eq(event.cityName))
+                        .and(checkByCityName(cityName))
                 )
                 .orderBy(event.startTime.asc())
                 .offset(start)
@@ -237,8 +237,18 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .select(eventForm.count())
                 .from(eventForm)
                 .join(event).on(eventForm.eventId.eq(event.id))
-                .where(event.cityName.eq(cityName))
+                .where(checkByCityName(cityName))
                 .fetchOne();
+    }
+
+    private BooleanBuilder checkByCityName(CityName cityName){
+        if(cityName==null){
+            return new BooleanBuilder();
+        } else if(cityName.equals(CityName.BUSAN)) {
+            return new BooleanBuilder(event.cityName.eq(CityName.BUSAN));
+        } else{
+            return new BooleanBuilder(event.cityName.eq(CityName.SEOUL));
+        }
     }
 
 

--- a/run/src/main/java/com/guide/run/event/service/EventGetService.java
+++ b/run/src/main/java/com/guide/run/event/service/EventGetService.java
@@ -45,43 +45,60 @@ public class EventGetService {
        return MyEventResponse.builder().items(myEvents).build();
     }
 
-    public long getAllEventListCount(String sort, EventType type, EventRecruitStatus kind, String privateId, CityName cityName){
-        if(sort.equals("UPCOMING")){
-            if(type.equals(TOTAL)){
-                if(kind.equals(RECRUIT_ALL)){
-                    return eventRepository.countByRecruitStatusNotAndIsApproveAndCityName(RECRUIT_END,true,cityName);
+    public long getAllEventListCount(String sort, EventType type, EventRecruitStatus kind, String privateId, CityName cityName) {
+        if (sort.equals("UPCOMING")) {
+            if (type.equals(TOTAL)) {
+                if (kind.equals(RECRUIT_ALL)) {
+                    if (cityName == null) {
+                        return eventRepository.countByRecruitStatusNotAndIsApprove(RECRUIT_END, true);
+                    }
+                    return eventRepository.countByRecruitStatusNotAndIsApproveAndCityName(RECRUIT_END, true, cityName);
+                } else {
+                    if (cityName == null) {
+                        return eventRepository.countByRecruitStatusAndIsApprove(kind, true);
+                    }
+                    return eventRepository.countByRecruitStatusAndIsApproveAndCityName(kind, true, cityName);
                 }
-                else{
-                    return eventRepository.countByRecruitStatusAndIsApproveAndCityName(kind,true,cityName);
-                }
-            }else{
-                if(kind.equals(RECRUIT_ALL)){
-                    return eventRepository.countByTypeAndRecruitStatusNotAndIsApproveAndCityName(type, RECRUIT_END,true,cityName);
-                }
-                else{
-                    return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type,kind,true,cityName);
+            } else {
+                if (kind.equals(RECRUIT_ALL)) {
+                    if (cityName == null) {
+                        return eventRepository.countByTypeAndRecruitStatusNotAndIsApprove(type, RECRUIT_END, true);
+                    }
+                    return eventRepository.countByTypeAndRecruitStatusNotAndIsApproveAndCityName(type, RECRUIT_END, true, cityName);
+                } else {
+                    if (cityName == null) {
+                        return eventRepository.countByTypeAndRecruitStatusAndIsApprove(type, kind, true);
+                    }
+                    return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type, kind, true, cityName);
                 }
             }
-        }else if(sort.equals("END")){
-            if(type.equals(TOTAL)){
-                return eventRepository.countByRecruitStatusAndIsApproveAndCityName(RECRUIT_END,true,cityName);
-            }else{
-                return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type, RECRUIT_END,true,cityName);
+        } else if (sort.equals("END")) {
+            if (type.equals(TOTAL)) {
+                if (cityName == null) {
+                    return eventRepository.countByRecruitStatusAndIsApprove(RECRUIT_END, true);
+                }
+                return eventRepository.countByRecruitStatusAndIsApproveAndCityName(RECRUIT_END, true, cityName);
+            } else {
+                if (cityName == null) {
+                    return eventRepository.countByTypeAndRecruitStatusAndIsApprove(type, RECRUIT_END, true);
+                }
+                return eventRepository.countByTypeAndRecruitStatusAndIsApproveAndCityName(type, RECRUIT_END, true, cityName);
             }
-        }else{
-            if(type.equals(TOTAL)){
-                if(kind.equals(RECRUIT_ALL)){
-                    return eventRepository.countByPrivateIdAndCityName(privateId,cityName);
+        } else {
+            if (type.equals(TOTAL)) {
+                if (kind.equals(RECRUIT_ALL)) {
+                    if (cityName == null) {
+                        return eventFormRepository.countByPrivateId(privateId);
+                    }
+                    return eventRepository.countByPrivateIdAndCityName(privateId, cityName);
+                } else {
+                    return eventRepository.getAllMyEventListCount(null, kind, privateId, cityName);
                 }
-                else{
-                    return eventRepository.getAllMyEventListCount(null,kind,privateId,cityName);
-                }
-            }else{
-                if(kind.equals(RECRUIT_ALL)){
-                    return eventRepository.getAllMyEventListCount(type, null,privateId,cityName);
-                }
-                else{
-                    return eventRepository.getAllMyEventListCount(type,kind,privateId,cityName);
+            } else {
+                if (kind.equals(RECRUIT_ALL)) {
+                    return eventRepository.getAllMyEventListCount(type, null, privateId, cityName);
+                } else {
+                    return eventRepository.getAllMyEventListCount(type, kind, privateId, cityName);
                 }
             }
         }


### PR DESCRIPTION
이벤트 조회시 필터에 null이 들어오는 경우 전부 나오게 수정

<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
이벤트 전체 조회 수정

## **변경 내용**
필터에 지역값을 넣지 않는경우 에러가 발생하는 부분 전체가 나오도록 수정

## **관련 이슈**
Resolves: #123 ...(해결한 이슈 번호)

See also: #45 #6 ...(참고 이슈 번호)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 모집상태·승인 여부, 이벤트 타입·모집상태·승인 여부 기준의 이벤트 수 집계를 지원합니다.
  - 도시 미선택 시에도 전체/개인 이벤트 수를 집계할 수 있습니다.
- 버그 수정
  - 도시 필터가 올바르게 적용되지 않던 경우를 수정하고, 도시값이 없을 때 불필요한 필터를 제거해 정확한 결과를 제공합니다.
  - 전체/종료/예정 정렬별 카운트가 조건에 맞게 계산되도록 로직을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->