### PR TITLE
fix : 이벤트 조회 수정

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventGetController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventGetController.java
@@ -46,7 +46,7 @@ public class EventGetController {
     public ResponseEntity<Count> getAllEventListCount(@RequestParam("sort") String sort,
                                                       @RequestParam("type") EventType type,
                                                       @RequestParam("kind") EventRecruitStatus kind,
-                                                      @RequestParam("cityName") CityName cityName,
+                                                      @RequestParam(value = "cityName", required = false) CityName cityName,
                                                       HttpServletRequest request){
         if(sort.equals("UPCOMING") || sort.equals("END") || sort.equals("MY")){}
         else throw new NotValidSortException();

--- a/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
+++ b/run/src/main/java/com/guide/run/event/entity/repository/EventRepositoryImpl.java
@@ -237,7 +237,8 @@ public class EventRepositoryImpl implements EventRepositoryCustom{
                 .select(eventForm.count())
                 .from(eventForm)
                 .join(event).on(eventForm.eventId.eq(event.id))
-                .where(checkByCityName(cityName))
+                .where(checkByCityName(cityName)
+                        .and(eventForm.privateId.eq(privateId)))
                 .fetchOne();
     }
 


### PR DESCRIPTION
이벤트 조회시 필터에 값이 아예 안들어오는 경우 수정

<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
이벤트 조회 수정

## **변경 내용**
필터에 값이 아예 들어오지 않는 경우 전체 조회하도록 변경

## **관련 이슈**
Resolves: #123 ...(해결한 이슈 번호)

See also: #45 #6 ...(참고 이슈 번호)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이벤트 수 조회 시 도시 필터를 선택 사항으로 변경하여, 도시를 지정하지 않아도 전체 이벤트 수를 확인할 수 있습니다.

- 버그 수정
  - 이벤트 수 집계가 개인 식별자 기준으로 일관되게 적용되도록 개선했습니다. 도시를 지정한 경우엔 해당 도시와 개인 식별자 모두에 맞춰 정확한 수를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->