### PR TITLE
fix : 이벤트 조회 수정

### DIFF
--- a/run/src/main/java/com/guide/run/event/controller/EventGetController.java
+++ b/run/src/main/java/com/guide/run/event/controller/EventGetController.java
@@ -64,7 +64,7 @@ public class EventGetController {
     public ResponseEntity<AllEventResponse> getAllEventList(@RequestParam("sort") String sort,
                                                             @RequestParam("type") EventType type,
                                                             @RequestParam("kind") EventRecruitStatus kind,
-                                                            @RequestParam("cityName") CityName cityName,
+                                                            @RequestParam(value = "cityName", required = false) CityName cityName,
                                                             @RequestParam("limit") int limit,
                                                             @RequestParam("start") int start,
                                                             HttpServletRequest request){


### PR DESCRIPTION
이벤트 조회시 필터에 값이 아예 안들어오는 경우 수정

<!-- 풀리퀘 제목 -->
<!-- <TYPE>: 설명 <IssueNumber> -->

## **타입**
- [ ] Feat
- [x] Fix
- [ ] Refactor
- [ ] Style
- [ ] Rename
- [ ] Remove
- [ ] Comment
- [ ] Design
- [ ] Docs
- [ ] Core

## **작업 사항**
이벤트 조회 수정

## **변경 내용**
이벤트 조회시 필터에 값이 아예 안들어오는 경우 수정

## **관련 이슈**
Resolves: #123 ...(해결한 이슈 번호)

See also: #45 #6 ...(참고 이슈 번호)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 이벤트 목록 조회 API에서 cityName 쿼리 파라미터가 선택 사항으로 변경되었습니다. 이제 도시를 지정하지 않아도 요청할 수 있으며, 미지정 시 전체 지역 대상(또는 서비스 기본 기준)으로 이벤트가 반환됩니다. 기존에 cityName을 포함한 요청은 그대로 동작하여 하위 호환성이 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->